### PR TITLE
ETQ utilisateur je ne suis pas sollicité sur ma géolocalisation

### DIFF
--- a/client/app/profil/identites/autorite.js
+++ b/client/app/profil/identites/autorite.js
@@ -12,8 +12,9 @@ angular.module('impactApp')
         views: {
           '': {
             templateUrl: 'app/profil/identites/autorites.html',
-            controller: function($scope, $state, profile, currentUser, identite) {
+            controller: function($scope, $state, profile, currentUser, currentMdph, identite) {
               $scope.identite = identite;
+              $scope.currentMdph = currentMdph;
 
               $scope.forms = $state.current.data.forms;
 

--- a/client/app/profil/identites/autorites.html
+++ b/client/app/profil/identites/autorites.html
@@ -3,10 +3,10 @@
 
   <div class="row">
     <div class="col-sm-6">
-      <autorite-form identite="identite.parent1" id="1" required="true"></autorite-form>
+      <autorite-form identite="identite.parent1" id="1" current-mdph="currentMdph" required="true"></autorite-form>
     </div>
     <div class="col-sm-6">
-      <autorite-form identite="identite.parent2" id="2" required="false"></autorite-form>
+      <autorite-form identite="identite.parent2" id="2" current-mdph="currentMdph" required="false"></autorite-form>
     </div>
   </div>
 

--- a/client/app/profil/identites/autre.html
+++ b/client/app/profil/identites/autre.html
@@ -1,11 +1,6 @@
 <form id="profile-identites" aria-labelledby="infoPerso" name="infoForm" ng-submit="submit(infoForm)" novalidate>
   <h2>Identité de la personne</h2>
 
-  <!-- <div class="identity-form-actions">
-    <a ui-sref="^" class="btn btn-link" role="button">Annuler</a>
-    <button type="submit" name="submit" alt="Valider" class="btn btn-success">Valider</button>
-  </div> -->
-
   <section class="identite-section">
     <div class="form-group required" ng-class="{'has-error': !identite.type && infoForm.$submitted}">
       <fieldset>
@@ -42,9 +37,9 @@
       <label for="nomVoie" class="control-label">Adresse</label>
       <div class="input-group">
         <input type="search"
-          typeahead="result as result.properties.label for result in getAdress($viewValue, lat, long)"
+          typeahead="result as result.properties.label for result in getAdress($viewValue, currentMdph)"
           typeahead-min-length='3'
-          typeahead-on-select='fillAdressOnSelect($item)'
+          typeahead-on-select='fillAdressOnSelect($item, identite)'
           typeahead-wait-ms="100"
           typeahead-loading="loadingLocations"
           typeahead-no-results="noResults"

--- a/client/app/profil/identites/autre.js
+++ b/client/app/profil/identites/autre.js
@@ -22,21 +22,11 @@ angular.module('impactApp')
             return profile.identites.autre;
           }
         },
-        controller: function($scope, $state, profile, currentUser, identite, $window, AdressService) {
+        controller: function($scope, $state, profile, currentUser, currentMdph, identite, $window, AdressService) {
           $scope.identite = identite;
-
-          $window.navigator.geolocation.getCurrentPosition(function(position) {
-            $scope.lat = position.coords.latitude;
-            $scope.long = position.coords.longitude;
-          });
-
+          $scope.currentMdph = currentMdph;
           $scope.getAdress = AdressService.getAdress;
-
-          $scope.fillAdressOnSelect = function(result) {
-            $scope.identite.nomVoie = result.properties.name;
-            $scope.identite.code_postal = result.properties.postcode;
-            $scope.identite.localite = result.properties.city;
-          };
+          $scope.fillAdressOnSelect = AdressService.fillAdressOnSelect;
 
           $scope.submit = function(form) {
             if (form.$invalid) {

--- a/client/app/profil/identites/beneficiaire.html
+++ b/client/app/profil/identites/beneficiaire.html
@@ -107,9 +107,9 @@
       <div class="input-group">
         <input id="address"
           type="search"
-          typeahead="result as result.properties.label for result in getAdress($viewValue, lat, long)"
+          typeahead="result as result.properties.label for result in getAdress($viewValue, currentMdph)"
           typeahead-min-length='3'
-          typeahead-on-select='fillAdressOnSelect($item)'
+          typeahead-on-select='fillAdressOnSelect($item, identite)'
           typeahead-wait-ms="100"
           typeahead-loading="loadingLocations"
           typeahead-no-results="noResults"

--- a/client/app/profil/identites/beneficiaire.js
+++ b/client/app/profil/identites/beneficiaire.js
@@ -25,27 +25,17 @@ angular.module('impactApp')
 
         controller: function($scope, $state, ProfileService, profile, currentUser, identite, $window, AdressService, currentMdph) {
           $scope.identite = identite;
+          $scope.currentMdph = currentMdph;
+          $scope.getAdress = AdressService.getAdress;
+          $scope.fillAdressOnSelect = AdressService.fillAdressOnSelect;
 
           if (!identite.email) {
             identite.email = currentUser.email;
           }
 
-          if (currentMdph.coordinates) {
-            $scope.lat = currentMdph.coordinates.coordy;
-            $scope.long = currentMdph.coordinates.coordx;
-          }
-
-          $scope.getAdress = AdressService.getAdress;
-
           if ($scope.identite.email === currentUser.email) {
             $scope.cbEmail = true;
           }
-
-          $scope.fillAdressOnSelect = function(result) {
-            $scope.identite.nomVoie = result.properties.name;
-            $scope.identite.code_postal = result.properties.postcode;
-            $scope.identite.localite = result.properties.city;
-          };
 
           $scope.submit = function(form) {
             if (form.$invalid) {

--- a/client/components/adresse.data.gouv/adresse.data.gouv.js
+++ b/client/components/adresse.data.gouv/adresse.data.gouv.js
@@ -3,20 +3,26 @@
 angular.module('impactApp')
   .factory('AdressService', function($http, appConfig) {
     return {
-      getAdress: function(val, lat, long) {
+      getAdress(val, mdph) {
         return $http({
           method: 'GET',
           url: appConfig.banUrl,
           params: {
             q: val,
-            lat: lat,
-            lon: long,
+            lat: mdph.coordinates.coordy,
+            lon: mdph.coordinates.coordx,
             limit: 8
           }
         })
         .then(function(response) {
           return response.data.features;
         });
+      },
+
+      fillAdressOnSelect(result, identite) {
+        identite.nomVoie = result.properties.name;
+        identite.code_postal = result.properties.postcode;
+        identite.localite = result.properties.city;
       }
     };
   });

--- a/client/components/autorite-form/autorite.component.js
+++ b/client/components/autorite-form/autorite.component.js
@@ -7,6 +7,7 @@ angular.module('impactApp').component('autoriteForm', {
   bindings: {
     identite: '=',
     id: '<',
-    required: '<'
+    required: '<',
+    currentMdph: '<',
   }
 });

--- a/client/components/autorite-form/autorite.controller.js
+++ b/client/components/autorite-form/autorite.controller.js
@@ -1,10 +1,11 @@
 'use strict';
 
 angular.module('impactApp')
-  .controller('AutoriteCtrl', function($state, $scope, identite, AdressService, $window, id, currentMdph) {
-      $scope.identite = identite;
-      $scope.id = id;
-      $scope.currentMdph = currentMdph;
+  .controller('AutoriteCtrl', function($state, $scope, AdressService, $window) {
+      $scope.identite = this.identite;
+      $scope.id = this.id;
+      $scope.required = this.required;
+      $scope.currentMdph = this.currentMdph;
       $scope.getAdress = AdressService.getAdress;
       $scope.fillAdressOnSelect = AdressService.fillAdressOnSelect;
 

--- a/client/components/autorite-form/autorite.controller.js
+++ b/client/components/autorite-form/autorite.controller.js
@@ -1,19 +1,14 @@
 'use strict';
 
 angular.module('impactApp')
-  .controller('AutoriteCtrl', function($state, $scope, AdressService, $window) {
-      $scope.identite = this.identite;
-      $scope.id = this.id;
-      $scope.required = this.required;
+  .controller('AutoriteCtrl', function($state, $scope, identite, AdressService, $window, id, currentMdph) {
+      $scope.identite = identite;
+      $scope.id = id;
+      $scope.currentMdph = currentMdph;
+      $scope.getAdress = AdressService.getAdress;
+      $scope.fillAdressOnSelect = AdressService.fillAdressOnSelect;
 
       $scope.forms = $state.current.data.forms;
-
-      $window.navigator.geolocation.getCurrentPosition(function(position) {
-        $scope.lat = position.coords.latitude;
-        $scope.long = position.coords.longitude;
-      });
-
-      $scope.getAdress = AdressService.getAdress;
 
       $scope.hasError = function(name) {
         return $scope.required ? $scope.forms.infoForm['' + name + this.id].$invalid : false;
@@ -21,12 +16,6 @@ angular.module('impactApp')
 
       $scope.getError = function(name) {
         return $scope.forms.infoForm['' + name + this.id].$error;
-      };
-
-      $scope.fillAdressOnSelect = function(result) {
-        $scope.identite.nomVoie = result.properties.name;
-        $scope.identite.code_postal = result.properties.postcode;
-        $scope.identite.localite = result.properties.city;
       };
 
       $scope.changeIsSameAddress = function() {

--- a/client/components/autorite-form/autorite.controller.js
+++ b/client/components/autorite-form/autorite.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('impactApp')
-  .controller('AutoriteCtrl', function($state, $scope, AdressService, $window) {
+  .controller('AutoriteCtrl', function($state, $scope, AdressService) {
       $scope.identite = this.identite;
       $scope.id = this.id;
       $scope.required = this.required;

--- a/client/components/autorite-form/autorite.html
+++ b/client/components/autorite-form/autorite.html
@@ -43,9 +43,9 @@
         <label for="nomVoie{{id}}" class="control-label">Adresse</label>
         <div class="input-group">
           <input type="search"
-            typeahead="result as result.properties.label for result in getAdress($viewValue, lat, long)"
+            typeahead="result as result.properties.label for result in getAdress($viewValue, currentMdph)"
             typeahead-min-length='3'
-            typeahead-on-select='fillAdressOnSelect($item)'
+            typeahead-on-select='fillAdressOnSelect($item, identite)'
             typeahead-wait-ms="100"
             typeahead-loading="loadingLocations"
             typeahead-no-results="noResults"


### PR DESCRIPTION
Le comportement actuel est différent sur chaque écran d'identité (bénéficiaire / autorité parentale / aidant / organisme).
Je reprend le comportement de l'écran bénéficiaire pour faire converger chaque écran:
 - On ne demande plus la géolocalisation de chaque utilisateur (plus de popup)
 - On utilise les coordonnées GPS de la MDPH pour affiner les résultats de recherche de la BAN