### PR TITLE
ETQ agent, je n'ai pas accès à la configuration des autres MDPH

### DIFF
--- a/client/app/dashboard/dispatch/dispatch.js
+++ b/client/app/dashboard/dispatch/dispatch.js
@@ -13,7 +13,7 @@ angular.module('impactApp')
         url: '/regles',
         templateUrl: 'app/dashboard/dispatch/regles/regles.html',
         controller: function($scope, DispatchRuleResource, currentMdph) {
-          $scope.dispatchRules = DispatchRuleResource.query({mdph: currentMdph._id});
+          $scope.dispatchRules = DispatchRuleResource.query({mdph: currentMdph.zipcode});
         },
 
         authenticate: true
@@ -23,16 +23,16 @@ angular.module('impactApp')
         templateUrl: 'app/dashboard/dispatch/regles/edit/edit.html',
         controller: 'DispatchRuleEditCtrl',
         resolve: {
-          dispatchRule: function(DispatchRuleResource, $stateParams) {
+          dispatchRule: function(DispatchRuleResource, $stateParams, currentMdph) {
             if ($stateParams.id) {
-              return DispatchRuleResource.get({id: $stateParams.id}).$promise;
+              return DispatchRuleResource.get({mdph: currentMdph.zipcode, id: $stateParams.id}).$promise;
             } else {
               return new DispatchRuleResource();
             }
           },
 
           secteurs: function(SecteurResource, currentMdph) {
-            return SecteurResource.query({mdph: currentMdph._id}).$promise;
+            return SecteurResource.query({mdph: currentMdph.zipcode}).$promise;
           },
 
           zipcodes: function() {
@@ -45,11 +45,11 @@ angular.module('impactApp')
       .state('dashboard.dispatch.secteurs', {
         url: '/secteurs',
         templateUrl: 'app/dashboard/dispatch/secteurs/secteurs.html',
-        controller: function($scope, secteurs) {
+        controller: function($scope, secteurs, currentMdph) {
           $scope.secteurs = secteurs;
 
           $scope.delete = function(secteur, idx) {
-            secteur.$delete(function() {
+            secteur.$delete({mdph: currentMdph.zipcode}, function() {
               $scope.secteurs.splice(idx, 1);
             });
           };
@@ -57,7 +57,7 @@ angular.module('impactApp')
 
         resolve: {
           secteurs: function(SecteurResource, currentMdph) {
-            return SecteurResource.query({mdph: currentMdph._id}).$promise;
+            return SecteurResource.query({mdph: currentMdph.zipcode}).$promise;
           }
         },
         authenticate: true
@@ -67,9 +67,9 @@ angular.module('impactApp')
         templateUrl: 'app/dashboard/dispatch/secteurs/edit/edit.html',
         controller: 'SecteurEditCtrl',
         resolve: {
-          secteur: function(SecteurResource, $stateParams) {
+          secteur: function(SecteurResource, $stateParams, currentMdph) {
             if ($stateParams.id) {
-              return SecteurResource.get({id: $stateParams.id}).$promise;
+              return SecteurResource.get({mdph: currentMdph.zipcode, id: $stateParams.id}).$promise;
             } else {
               return new SecteurResource();
             }

--- a/client/app/dashboard/dispatch/regles/edit/edit.controller.js
+++ b/client/app/dashboard/dispatch/regles/edit/edit.controller.js
@@ -16,7 +16,7 @@ angular.module('impactApp')
         enfant: $scope.secteurEnfant,
       };
       dispatchRule.mdph = currentMdph._id;
-      dispatchRule.$save(function() {
+      dispatchRule.$save({mdph: currentMdph.zipcode}, function() {
         $state.go('^', {}, {reload: true});
       });
     };
@@ -26,7 +26,7 @@ angular.module('impactApp')
     };
 
     $scope.delete = function() {
-      dispatchRule.$delete(function() {
+      dispatchRule.$delete({mdph: currentMdph.zipcode}, function() {
         $state.go('^', {}, {reload: true});
       });
     };

--- a/client/app/dashboard/dispatch/secteurs/edit/edit.controller.js
+++ b/client/app/dashboard/dispatch/secteurs/edit/edit.controller.js
@@ -29,7 +29,7 @@ angular.module('impactApp')
       secteur.name = $scope.name;
       secteur.default = $scope.default;
       secteur.mdph = currentMdph._id;
-      secteur.$save(function() {
+      secteur.$save({mdph: currentMdph.zipcode}, function() {
         $state.go('^', {}, {reload: true});
       });
     };

--- a/client/components/resources/dispatch-rule.resource.js
+++ b/client/components/resources/dispatch-rule.resource.js
@@ -2,7 +2,7 @@
 
 angular.module('impactApp')
   .factory('DispatchRuleResource', function($resource) {
-    return $resource('/api/dispatch-rules/:id', {
-      id: '@_id'
+    return $resource('/api/mdphs/:mdph/dispatch-rules/:id', {
+      id: '@_id',
     });
   });

--- a/client/components/resources/secteur.resource.js
+++ b/client/components/resources/secteur.resource.js
@@ -2,7 +2,7 @@
 
 angular.module('impactApp')
   .factory('SecteurResource', function($resource) {
-    return $resource('/api/secteurs/:id', {
+    return $resource('/api/mdphs/:mdph/secteurs/:id', {
       id: '@_id'
     });
   });

--- a/server/api/dispatch-rule/index.js
+++ b/server/api/dispatch-rule/index.js
@@ -6,11 +6,11 @@ import * as controller from './dispatch-rule.controller';
 
 var router = new Router();
 
-router.get('/', hasRole('adminMdph'), controller.index);
-router.post('/', hasRole('adminMdph'), controller.create);
-router.get('/:id', hasRole('adminMdph'), controller.show);
-router.post('/:id', hasRole('adminMdph'), controller.update);
-router.patch('/:id', hasRole('adminMdph'), controller.update);
-router.delete('/:id', hasRole('adminMdph'), controller.destroy);
+router.get('/', controller.index);
+router.post('/', controller.create);
+router.get('/:id', controller.show);
+router.post('/:id', controller.update);
+router.patch('/:id', controller.update);
+router.delete('/:id', controller.destroy);
 
 module.exports = router;

--- a/server/api/dispatch-rule/index.js
+++ b/server/api/dispatch-rule/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import {Router} from 'express';
-import {hasRole} from '../../auth/auth.service';
 import * as controller from './dispatch-rule.controller';
 
 var router = new Router();

--- a/server/api/mdph/index.js
+++ b/server/api/mdph/index.js
@@ -6,6 +6,8 @@ import {hasRole, isAgent} from '../../auth/auth.service';
 import categoriesRouter from '../document-category';
 import Mdph from './mdph.model';
 import synthesesRouter from '../synthese';
+import dispatchRuleRouter from '../dispatch-rule';
+import secteurRouter from '../secteur';
 
 var router = new Router();
 
@@ -35,6 +37,8 @@ router.post('/:id/like', controller.saveLike);
 
 router.use('/:id/categories', isAgent(), categoriesRouter);
 router.use('/:id/syntheses',  isAgent(), synthesesRouter);
+router.use('/:id/dispatch-rules',  isAgent(), dispatchRuleRouter);
+router.use('/:id/secteurs',  isAgent(), secteurRouter);
 
 
 router.param('id', function(req, res, next, id) {

--- a/server/api/secteur/index.js
+++ b/server/api/secteur/index.js
@@ -6,11 +6,11 @@ import * as controller from './secteur.controller';
 
 var router = new Router();
 
-router.get('/', hasRole('adminMdph'), controller.index);
-router.post('/', hasRole('adminMdph'), controller.create);
-router.get('/:id', hasRole('adminMdph'), controller.show);
-router.post('/:id', hasRole('adminMdph'), controller.update);
-router.patch('/:id', hasRole('adminMdph'), controller.update);
-router.delete('/:id', hasRole('adminMdph'), controller.destroy);
+router.get('/', controller.index);
+router.post('/', controller.create);
+router.get('/:id', controller.show);
+router.post('/:id', controller.update);
+router.patch('/:id', controller.update);
+router.delete('/:id', controller.destroy);
 
 module.exports = router;

--- a/server/api/secteur/index.js
+++ b/server/api/secteur/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import {hasRole} from '../../auth/auth.service';
 import {Router} from 'express';
 import * as controller from './secteur.controller';
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -15,9 +15,7 @@ export default function(app) {
   app.use('/api/prestations', require('./api/prestation'));
   app.use('/api/partenaires', require('./api/partenaire'));
   app.use('/api/geva', require('./api/geva'));
-  app.use('/api/dispatch-rules', require('./api/dispatch-rule'));
   app.use('/api/sections', require('./api/sections'));
-  app.use('/api/secteurs', require('./api/secteur'));
   app.use('/api/stats', require('./api/stats'));
   app.use('/api/document-types', require('./api/document-type'));
 


### PR DESCRIPTION
Les écrans "Distribution des demandes" et "Gestion des secteurs" devraient encore être totalement fonctionnels.

On ne peut plus accéder aux écrans des autres MDPHs en changeant l'identifiant dans l'URL (ex: http://localhost:9000/mdph/test/dashboard/dispatch/regles -> http://localhost:9000/mdph/59/dashboard/dispatch/regles )