### PR TITLE
 Côté Agent, dans "Paramétrer l'export des demandes", effacer le nom de la catégorie obligatoire de "Documents catégorisés" produit une erreur 503 sur l'intégralité du site MDPH en ligne

### DIFF
--- a/client/app/dashboard/documents/documents.controller.js
+++ b/client/app/dashboard/documents/documents.controller.js
@@ -108,7 +108,7 @@ angular.module('impactApp')
     };
 
     $scope.save = function(category) {
-      if(category.label.length !== 0){
+      if (category.label.length !== 0) {
         category.$save({zipcode: currentMdph.zipcode}).then(function() {
           showAlert();
         },

--- a/client/app/dashboard/documents/documents.controller.js
+++ b/client/app/dashboard/documents/documents.controller.js
@@ -108,13 +108,15 @@ angular.module('impactApp')
     };
 
     $scope.save = function(category) {
-      category.$save({zipcode: currentMdph.zipcode}).then(function() {
-        showAlert();
-      },
+      if(category.label.length !== 0){
+        category.$save({zipcode: currentMdph.zipcode}).then(function() {
+          showAlert();
+        },
 
-      function() {
-        showAlert(true);
-      });
+        function() {
+          showAlert(true);
+        });
+      }
     };
 
     $scope.deleteSeparator = function(category) {


### PR DESCRIPTION
Désormais, on enregistre le nom de la catégorie apres saisie d'au moins un caractere. si le champ est vide ucune action n'est exécuté.