### PR TITLE
ETQ utilisateur de l'outil de soutien, je peux déplier les sections contenant les champs cochables à l’aide d’un signe « + »

### DIFF
--- a/client/app/evaluation/detail/evaluation.detail.controller.js
+++ b/client/app/evaluation/detail/evaluation.detail.controller.js
@@ -54,11 +54,11 @@ angular.module('impactApp')
 
     function hasQuestionSelected(question) {
       if (question.Reponses) {
-        for (let quest of question.Reponses) {
-          if (quest.isSelected) {
+        for (let i = 0; i < question.Reponses.length; i++) {
+          if (question.Reponses[i].isSelected) {
             return true;
           } else {
-            if (hasQuestionSelected(quest)) {
+            if (hasQuestionSelected(question.Reponses[i])) {
               return true;
             }
           }

--- a/client/app/evaluation/detail/evaluation.detail.controller.js
+++ b/client/app/evaluation/detail/evaluation.detail.controller.js
@@ -61,8 +61,29 @@ angular.module('impactApp')
             reponses = answersToIdArray(question.Reponses, level + 1);
             result = result.concat(reponses);
           }
-
           if (level !== 0 || reponses.length > 0) {
+          //if (  /*level === 0 && */reponses.length > 0 ||  level !== 0 && (!question.Reponses || result.length > 0) ) {
+            result.push(question.id);
+          } else {
+            question.isSelected = false;
+          }
+        }
+
+        return result;
+      }, []);
+    }
+
+    function answersToIdArrayToSave(root, level) {
+      return _.reduce(root, function(result, question) {
+        if (question.isSelected) {
+          var reponses = [];
+
+          if (question.Reponses) {
+            reponses = answersToIdArrayToSave(question.Reponses, level + 1);
+            result = result.concat(reponses);
+          }
+          //if (level !== 0 || reponses.length > 0) {
+          if (  /*level === 0 && */reponses.length > 0 ||  level !== 0 && (!question.Reponses || result.length > 0) ) {
             result.push(question.id);
           } else {
             question.isSelected = false;
@@ -76,6 +97,12 @@ angular.module('impactApp')
     function trajectoiresToIdArray(trajectoires) {
       return _.reduce(trajectoires, function(result, trajectoire) {
         return result.concat(answersToIdArray(trajectoire, 0));
+      }, []);
+    }
+
+    function trajectoiresToIdArrayToSave(trajectoires) {
+      return _.reduce(trajectoires, function(result, trajectoire) {
+        return result.concat(answersToIdArrayToSave(trajectoire, 0));
       }, []);
     }
 
@@ -121,11 +148,12 @@ angular.module('impactApp')
     };
 
     $scope.$on('saveEvaluationDetailEvent', function() {
-      currentSynthese.geva[section.id] = trajectoiresToIdArray($scope.section.trajectoires);
+      currentSynthese.geva[section.id] = trajectoiresToIdArrayToSave($scope.section.trajectoires);
       $scope.noAnswer = (currentSynthese.geva[section.id].length === 0);
       SyntheseResource.update(currentSynthese, function() {
         toastr.info('Sauvegarde de la fiche de synthèse effectuée', 'Information');
       });
+      currentSynthese.geva[section.id] = trajectoiresToIdArray($scope.section.trajectoires);
     });
 
   });

--- a/client/app/evaluation/detail/evaluation.detail.controller.js
+++ b/client/app/evaluation/detail/evaluation.detail.controller.js
@@ -61,8 +61,8 @@ angular.module('impactApp')
             reponses = answersToIdArray(question.Reponses, level + 1);
             result = result.concat(reponses);
           }
+
           if (level !== 0 || reponses.length > 0) {
-          //if (  /*level === 0 && */reponses.length > 0 ||  level !== 0 && (!question.Reponses || result.length > 0) ) {
             result.push(question.id);
           } else {
             question.isSelected = false;
@@ -71,6 +71,18 @@ angular.module('impactApp')
 
         return result;
       }, []);
+    }
+
+    function hasChildToSave(question, result) {
+      if (result && result.length > 0) {
+        for (let quest of result) {
+          if (quest.includes(question.id)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
     }
 
     function answersToIdArrayToSave(root, level) {
@@ -82,8 +94,9 @@ angular.module('impactApp')
             reponses = answersToIdArrayToSave(question.Reponses, level + 1);
             result = result.concat(reponses);
           }
-          //if (level !== 0 || reponses.length > 0) {
-          if (  /*level === 0 && */reponses.length > 0 ||  level !== 0 && (!question.Reponses || result.length > 0) ) {
+
+          // enregistrer seulement les réponses selectionnées et les questions intermédiaires correspondantes
+          if (level === 0 && reponses.length > 0 ||  level !== 0 && (!question.Reponses || hasChildToSave(question, result))) {
             result.push(question.id);
           } else {
             question.isSelected = false;
@@ -153,6 +166,7 @@ angular.module('impactApp')
       SyntheseResource.update(currentSynthese, function() {
         toastr.info('Sauvegarde de la fiche de synthèse effectuée', 'Information');
       });
+
       currentSynthese.geva[section.id] = trajectoiresToIdArray($scope.section.trajectoires);
     });
 

--- a/client/app/evaluation/detail/evaluation.detail.html
+++ b/client/app/evaluation/detail/evaluation.detail.html
@@ -51,8 +51,8 @@
           <div ng-repeat="(trajectoire, questions) in section.trajectoires" class="trajectoire-body">
             <h4 ng-if="trajectoire !== 'Toutes'">Trajectoires - {{trajectoire}}</h4>
             <trajectoire questions="questions"
-                         current-question-id="currentQuestionId"
-                         new-issue="newIssue" read-only="currentSynthese.request">
+                         new-issue="newIssue"
+                         read-only="currentSynthese.request">
             </trajectoire>
           </div>
         </div>

--- a/client/app/evaluation/detail/evaluation.detail.html
+++ b/client/app/evaluation/detail/evaluation.detail.html
@@ -52,7 +52,6 @@
             <h4 ng-if="trajectoire !== 'Toutes'">Trajectoires - {{trajectoire}}</h4>
             <trajectoire questions="questions"
                          current-question-id="currentQuestionId"
-                         current-sub-question-id="currentSubQuestionId"
                          new-issue="newIssue" read-only="currentSynthese.request">
             </trajectoire>
           </div>

--- a/client/app/evaluation/detail/evaluation.detail.html
+++ b/client/app/evaluation/detail/evaluation.detail.html
@@ -50,7 +50,11 @@
         <div class="panel-body" ng-if="section.id != 'profile'">
           <div ng-repeat="(trajectoire, questions) in section.trajectoires" class="trajectoire-body">
             <h4 ng-if="trajectoire !== 'Toutes'">Trajectoires - {{trajectoire}}</h4>
-            <trajectoire questions="questions" current-question-id="currentQuestionId" new-issue="newIssue" read-only="currentSynthese.request"></trajectoire>
+            <trajectoire questions="questions"
+                         current-question-id="currentQuestionId"
+                         current-sub-question-id="currentSubQuestionId"
+                         new-issue="newIssue" read-only="currentSynthese.request">
+            </trajectoire>
           </div>
         </div>
 

--- a/client/components/trajectoire/trajectoire.component.js
+++ b/client/components/trajectoire/trajectoire.component.js
@@ -7,6 +7,7 @@ angular.module('impactApp').component('trajectoire', {
     questions: '=',
     request: '=',
     currentQuestionId: '=',
+    currentSubQuestionId: '=',
     root: '=',
     readOnly: '=',
     newIssue: '='

--- a/client/components/trajectoire/trajectoire.component.js
+++ b/client/components/trajectoire/trajectoire.component.js
@@ -6,7 +6,6 @@ angular.module('impactApp').component('trajectoire', {
     sublevel: '=',
     questions: '=',
     request: '=',
-    currentQuestionId: '=',
     root: '=',
     readOnly: '=',
     newIssue: '='

--- a/client/components/trajectoire/trajectoire.component.js
+++ b/client/components/trajectoire/trajectoire.component.js
@@ -7,7 +7,6 @@ angular.module('impactApp').component('trajectoire', {
     questions: '=',
     request: '=',
     currentQuestionId: '=',
-    currentSubQuestionId: '=',
     root: '=',
     readOnly: '=',
     newIssue: '='

--- a/client/components/trajectoire/trajectoire.controller.js
+++ b/client/components/trajectoire/trajectoire.controller.js
@@ -11,16 +11,8 @@ angular.module('impactApp')
       }
     };
 
-    this.isCurrentQuestion = (question) => {
-      if (this.currentQuestionId !== null) {
-        return (this.currentQuestionId === (this.getRootQuestion(question)).id);
-      } else {
-        return false;
-      }
-    };
-
     this.filterQuestion = (question) => {
-        return ((!this.sublevel && !this.readOnly) || question.isOpen || question.isParentOpen || !this.sublevel && this.isCurrentQuestion(question)  || question.isSelected || this.hasQuestionSelected(question));
+        return ((!this.sublevel && !this.readOnly) || question.isOpen || question.isParentOpen || question.isSelected || this.hasQuestionSelected(question));
       };
 
     function closeTree(question) {
@@ -33,7 +25,7 @@ angular.module('impactApp')
       }
     }
 
-    function reverseIsOpen(question, questions) {
+    this.toggleCollapse = (question, questions) => {
       question.isOpen = !question.isOpen;
       if (question.isOpen) {
         if (question.Reponses) {
@@ -42,23 +34,21 @@ angular.module('impactApp')
           }
         }
       } else {
-        for (let i = 0; i < questions.length; i++) {
-          if (question.id === questions[i].id) {
-            closeTree(questions[i]);
-            break;
+        if (questions) {
+          for (let i = 0; i < questions.length; i++) {
+            if (question.id === questions[i].id) {
+              closeTree(questions[i]);
+              break;
+            }
           }
         }
       }
-    }
+    };
 
     this.toggleSelected = (question, questions) => {
       question.isSelected = !question.isSelected;
       if ((question.isOpen ? true : false) !== question.isSelected) {
-        reverseIsOpen(question, questions);
-      }
-
-      if (question.isSelected) {
-        this.currentQuestionId = (this.getRootQuestion(question)).id;
+        this.toggleCollapse(question, questions);
       }
 
       if (question.isSelected && this.sublevel) {
@@ -68,15 +58,6 @@ angular.module('impactApp')
       if (this.sublevel) {
         // Emetre en evenement pour la sauvegarde
         $scope.$emit('saveEvaluationDetailEvent');
-      }
-
-    };
-
-    this.isCurrentQuestion = (question) => {
-      if (this.currentQuestionId !== null) {
-        return (this.currentQuestionId === (this.getRootQuestion(question)).id);
-      } else {
-        return false;
       }
     };
 
@@ -95,19 +76,4 @@ angular.module('impactApp')
 
       return false;
     };
-
-    this.toggleCollapse = (question, questions) => {
-      reverseIsOpen(question, questions);
-      if (this.currentQuestionId !== (this.getRootQuestion(question)).id) {
-        this.currentQuestionId = (this.getRootQuestion(question)).id;
-      } else {
-        this.currentQuestionId = null;
-      }
-
-    };
-
-    this.toggleCollapseSublevel = (question, questions) => {
-      reverseIsOpen(question, questions);
-    };
-
   });

--- a/client/components/trajectoire/trajectoire.controller.js
+++ b/client/components/trajectoire/trajectoire.controller.js
@@ -100,21 +100,14 @@ angular.module('impactApp')
       reverseIsOpen(question, questions);
       if (this.currentQuestionId !== (this.getRootQuestion(question)).id) {
         this.currentQuestionId = (this.getRootQuestion(question)).id;
-        this.currentSubQuestionId = question.id;
       } else {
         this.currentQuestionId = null;
-        this.currentSubQuestionId = null;
       }
 
     };
 
     this.toggleCollapseSublevel = (question, questions) => {
       reverseIsOpen(question, questions);
-      if (this.currentSubQuestionId !== (question.id)) {
-        this.currentSubQuestionId = question.id;
-      } else {
-        this.currentSubQuestionId = null;
-      }
     };
 
   });

--- a/client/components/trajectoire/trajectoire.controller.js
+++ b/client/components/trajectoire/trajectoire.controller.js
@@ -27,11 +27,9 @@ angular.module('impactApp')
 
     this.toggleCollapse = (question, questions) => {
       question.isOpen = !question.isOpen;
-      if (question.isOpen) {
-        if (question.Reponses) {
-          for (let quest of question.Reponses) {
-            quest.isParentOpen = true;
-          }
+      if (question.isOpen && question.Reponses) {
+        for (let i = 0; i < question.Reponses.length; i++) {
+          question.Reponses[i].isParentOpen = true;
         }
       } else {
         if (questions) {
@@ -63,11 +61,11 @@ angular.module('impactApp')
 
     this.hasQuestionSelected = (question) => {
       if (question.Reponses) {
-        for (let quest of question.Reponses) {
-          if (quest.isSelected) {
+        for (let i = 0; i < question.Reponses.length; i++) {
+          if (question.Reponses[i].isSelected) {
             return true;
           } else {
-            if (this.hasQuestionSelected(quest)) {
+            if (this.hasQuestionSelected(question.Reponses[i])) {
               return true;
             }
           }

--- a/client/components/trajectoire/trajectoire.controller.js
+++ b/client/components/trajectoire/trajectoire.controller.js
@@ -19,33 +19,84 @@ angular.module('impactApp')
       }
     };
 
+    this.isCurrentSubQuestion = (question) => {
+      if (this.currentSubQuestionId !== null) {
+        return (this.currentSubQuestionId === question.id);
+      } else {
+        return false;
+      }
+    };
+
     this.filterQuestion = (question) => {
-      return ((!this.sublevel && !this.readOnly) || this.isCurrentQuestion(question) || question.isSelected);
+      return ((!this.sublevel && !this.readOnly) || (!this.sublevel && this.isCurrentQuestion(question)) || (this.sublevel && this.isCurrentSubQuestion(question)) || question.isSelected);
     };
 
     this.toggleSelected = (question) => {
       question.isSelected = !question.isSelected;
 
-      if (question.isSelected) {
+      if(question.hasQuestionSelected){
         this.currentQuestionId = (this.getRootQuestion(question)).id;
+        this.currentSubQuestionId = question.id;
       }
 
       if (question.isSelected && this.sublevel) {
         this.root.isSelected = true;
       }
 
-      if (this.sublevel) {
+      if (this.sublevel && !question.Reponses) {
         // Emetre en evenement pour la sauvegarde
         $scope.$emit('saveEvaluationDetailEvent');
       }
 
     };
 
+    this.toggleReduce = (question) => {
+
+      this.currentTraitementQuestionId = question.id;
+        this.currentQuestionId = question.id;
+
+
+
+       // this.root.isSelected = true;
+
+    };
+
     this.toggleCollapse = (question) => {
-      if (this.currentQuestionId !== (this.getRootQuestion(question)).id) {
+      if (this.sublevel || this.currentQuestionId !== (this.getRootQuestion(question)).id) {
         this.currentQuestionId = (this.getRootQuestion(question)).id;
       } else {
         this.currentQuestionId = null;
       }
+      this.currentSubQuestionId = null;
     };
+
+    this.toggleCollapseSublevel = (question) => {
+      if (this.currentSubQuestionId !== (question.id)) {
+        this.currentSubQuestionId = question.id;
+        this.currentQuestionId = (this.getRootQuestion(question)).id;
+      } else {
+        this.currentSubQuestionId = null;
+
+        if(trjctrCtrl.sublevel && trjctrCtrl.currentSubQuestionId === question.id || trjctrCtrl.currentQuestionId === question.id || question.isSelected)
+        {alert ('tptpot');}
+
+
+      }
+    };
+
+
+
+
+
+    function hasQuestionSelectedd(question) {
+      for (let quest in question.Reponses) {
+        if (hasQuestionSelectedd(quest)) return true;
+      }
+      return question.isSelected ;
+    }
+
+    this.hasQuestionSelected  = (question) => {
+      return hasQuestionSelectedd(question);
+    };
+
   });

--- a/client/components/trajectoire/trajectoire.controller.js
+++ b/client/components/trajectoire/trajectoire.controller.js
@@ -19,56 +19,13 @@ angular.module('impactApp')
       }
     };
 
-    this.isCurrentSubQuestion = (question) => {
-
-      if (this.currentSubQuestionId !== null) {
-        return (this.currentSubQuestionId === question.id);
-      } else {
-        return false;
-      }
-    };
-
-    function hasChildInProgress(question) {
-      if (question.Reponses) {
-        for (let quest of question.Reponses) {
-          if (quest.parentInProgress) {
-            return true;
-          } else {
-            return hasChildInProgress(quest);
-          }
-        }
-      }
-
-      return false;
-    }
-
     this.filterQuestion = (question) => {
-        if (!question.isSelected && hasChildInProgress(question)) {
+        /*if (!question.isSelected && hasQuestionSelected(question)) {
           question.isSelected = true;
-        }
+        }*/
 
-        return ((!this.sublevel && !this.readOnly) || question.inProgress || question.parentInProgress || !this.sublevel && this.isCurrentQuestion(question)  || question.isSelected);
+        return ((!this.sublevel && !this.readOnly) || question.inProgress || question.parentInProgress || /*!this.sublevel &&*/ this.isCurrentQuestion(question)  || question.isSelected || this.hasQuestionSelected(question));
       };
-
-    this.toggleSelected = (question) => {
-      question.isSelected = !question.isSelected;
-      question.inProgress = !question.isSelected ? false : !question.inProgress;
-
-      if (question.isSelected && this.sublevel) {
-        this.root.isSelected = true;
-      }
-
-      if (this.sublevel && !question.Reponses) {
-        // Emetre en evenement pour la sauvegarde
-        $scope.$emit('saveEvaluationDetailEvent');
-      }
-
-    };
-
-    this.toggleReduce = (question) => {
-      this.currentTraitementQuestionId = question.id;
-      this.currentQuestionId = question.id;
-    };
 
     function initParentInProgress(question) {
       question.parentInProgress = false;
@@ -79,22 +36,6 @@ angular.module('impactApp')
       }
     }
 
-    function hasQuestionSelected(question) {
-      if (question.Reponses) {
-        for (let quest of question.Reponses) {
-          if (quest.isSelected) {
-            return true;
-          } else {
-            if (hasQuestionSelected(quest)) {
-              return true;
-            }
-          }
-        }
-      }
-
-      return false;
-    }
-
     function updateInProgress(question) {
       question.inProgress = !question.inProgress;
       if (question.Reponses) {
@@ -103,9 +44,54 @@ angular.module('impactApp')
           quest.parentInProgress = question.inProgress;
         }
       }
-
-      question.isSelected = hasQuestionSelected(question) ? true : !question.isSelected;
     }
+
+    this.toggleSelected = (question) => {
+      question.isSelected = !question.isSelected;
+      question.inProgress = !question.isSelected ? false : !question.inProgress;
+
+      if (question.isSelected) {
+        this.currentQuestionId = (this.getRootQuestion(question)).id;
+      }
+
+      if (question.isSelected && this.sublevel) {
+        this.root.isSelected = true;
+      }
+
+      if (!this.sublevel) {
+        updateInProgress(question);
+      }
+
+      if (this.sublevel /*&& !question.Reponses*/) {
+        // Emetre en evenement pour la sauvegarde
+        $scope.$emit('saveEvaluationDetailEvent');
+      }
+
+    };
+
+    this.isCurrentQuestion = (question) => {
+      if (this.currentQuestionId !== null) {
+        return (this.currentQuestionId === (this.getRootQuestion(question)).id);
+      } else {
+        return false;
+      }
+    };
+
+    this.hasQuestionSelected = (question) => {
+      if (question.Reponses) {
+        for (let quest of question.Reponses) {
+          if (quest.isSelected) {
+            return true;
+          } else {
+            if (this.hasQuestionSelected(quest)) {
+              return true;
+            }
+          }
+        }
+      }
+
+      return false;
+    };
 
     this.toggleCollapse = (question) => {
       updateInProgress(question);

--- a/client/components/trajectoire/trajectoire.controller.js
+++ b/client/components/trajectoire/trajectoire.controller.js
@@ -20,6 +20,7 @@ angular.module('impactApp')
     };
 
     this.isCurrentSubQuestion = (question) => {
+
       if (this.currentSubQuestionId !== null) {
         return (this.currentSubQuestionId === question.id);
       } else {
@@ -28,11 +29,15 @@ angular.module('impactApp')
     };
 
     this.filterQuestion = (question) => {
-      return ((!this.sublevel && !this.readOnly) || (!this.sublevel && this.isCurrentQuestion(question)) || (this.sublevel && this.isCurrentSubQuestion(question)) || question.isSelected);
+      console.log('filter ' + question.id + ' ' + question.Libelle + ' ' + question.question + ' '+ ( ((!this.sublevel && !this.readOnly) || question.inProgress || this.isCurrentQuestion(question) || question.isSelected) ? "vrai" : "faux") );
+
+        return ((!this.sublevel && !this.readOnly) || question.inProgress || !this.sublevel && this.isCurrentQuestion(question) || !this.sublevel && this.isCurrentSubQuestion(question) || question.isSelected  );
+
     };
 
     this.toggleSelected = (question) => {
       question.isSelected = !question.isSelected;
+      question.inProgress = true;
 
       if(question.hasQuestionSelected){
         this.currentQuestionId = (this.getRootQuestion(question)).id;
@@ -66,22 +71,32 @@ angular.module('impactApp')
         this.currentQuestionId = (this.getRootQuestion(question)).id;
       } else {
         this.currentQuestionId = null;
+        question.inProgress = false;
       }
       this.currentSubQuestionId = null;
+
+
+      if((!this.sublevel && !this.readOnly) || question.inProgress || this.isCurrentQuestion(question) || question.isSelected  && !question.Reponses){
+        console.log('toggleCollapse'+ question.id);
+      }
     };
 
     this.toggleCollapseSublevel = (question) => {
+      question.inProgress = !question.inProgress;
       if (this.currentSubQuestionId !== (question.id)) {
         this.currentSubQuestionId = question.id;
-        this.currentQuestionId = (this.getRootQuestion(question)).id;
+
       } else {
         this.currentSubQuestionId = null;
-
-        if(trjctrCtrl.sublevel && trjctrCtrl.currentSubQuestionId === question.id || trjctrCtrl.currentQuestionId === question.id || question.isSelected)
-        {alert ('tptpot');}
-
-
       }
+      if(!this.sublevel && this.currentQuestionId === question.id || question.isSelected  && !question.Reponses || question.inProgress){
+        console.log('toto');
+      }
+
+      if((!this.sublevel && !this.readOnly) || question.inProgress || this.isCurrentQuestion(question) || question.isSelected  && !question.Reponses){
+        console.log('toggleCollapseSublevel'+ question.id);
+      }
+
     };
 
 

--- a/client/components/trajectoire/trajectoire.controller.spec.js
+++ b/client/components/trajectoire/trajectoire.controller.spec.js
@@ -38,10 +38,10 @@ describe('TrajectoireController', function() {
         id: '1234',
         isSelected: false
       };
-      controller.toggleCollapse(question);
+      controller.toggleCollapse(question, {});
       expect(controller.currentQuestionId).toBe('1234');
 
-      controller.toggleCollapse(question);
+      controller.toggleCollapse(question, {});
       expect(controller.currentQuestionId).toBe(null);
     });
   });

--- a/client/components/trajectoire/trajectoire.controller.spec.js
+++ b/client/components/trajectoire/trajectoire.controller.spec.js
@@ -33,16 +33,15 @@ describe('TrajectoireController', function() {
       controller = $controller('TrajectoireController', { $scope: scope });
     });
 
-    it('should change the selected question', function() {
+    it('should open then close question', function() {
       var question = {
-        id: '1234',
-        isSelected: false
+        isOpen:false
       };
-      controller.toggleCollapse(question, {});
-      expect(controller.currentQuestionId).toBe('1234');
+      controller.toggleCollapse(question);
+      expect(question.isOpen).toBe(true);
 
-      controller.toggleCollapse(question, {});
-      expect(controller.currentQuestionId).toBe(null);
+      controller.toggleCollapse(question);
+      expect(question.isOpen).toBe(false);
     });
   });
 

--- a/client/components/trajectoire/trajectoire.html
+++ b/client/components/trajectoire/trajectoire.html
@@ -14,7 +14,7 @@ ng-class="{
     <button type="button" class="btn btn-link"
       ng-click="!trjctrCtrl.sublevel ? trjctrCtrl.toggleCollapse(question) : trjctrCtrl.toggleCollapseSublevel(question)"
       ng-if="( !trjctrCtrl.sublevel || question.Reponses) && !trjctrCtrl.readOnly">
-      <i class="fa" ng-class="((!trjctrCtrl.sublevel && trjctrCtrl.isCurrentQuestion(question) )  || trjctrCtrl.sublevel && trjctrCtrl.isCurrentSubQuestion(question) ) ?  'fa-minus': 'fa-plus' "></i>
+      <i class="fa" ng-class="((!trjctrCtrl.sublevel && trjctrCtrl.isCurrentQuestion(question) )  || trjctrCtrl.sublevel && question.inProgress) ?  'fa-minus': 'fa-plus' "></i>
     </button>
   </div>
 

--- a/client/components/trajectoire/trajectoire.html
+++ b/client/components/trajectoire/trajectoire.html
@@ -4,7 +4,7 @@ ng-class="{
   'main-level': !trjctrCtrl.sublevel}">
 <div ng-repeat="question in trjctrCtrl.questions" ng-if="trjctrCtrl.filterQuestion(question)">
   <div class="question" ng-class="{'question-active': question.isSelected}">
-    <button type="button" class="btn btn-link" ng-click="trjctrCtrl.toggleSelected(question)" ng-disabled="trjctrCtrl.readOnly">
+    <button type="button" class="btn btn-link" ng-click="trjctrCtrl.toggleSelected(question, trjctrCtrl.questions)" ng-disabled="trjctrCtrl.readOnly">
       <i class="fa" ng-class="question.isSelected ? 'fa-check-square-o' : 'fa-square-o'" aria-hidden="true" ng-if="trjctrCtrl.sublevel"></i>
       {{question.Question ? (question.Question | capitalizeString) : (question.Libelle | capitalizeString)}}
     </button>
@@ -12,14 +12,14 @@ ng-class="{
       Commenter
     </button>
     <button type="button" class="btn btn-link"
-      ng-click="!trjctrCtrl.sublevel ? trjctrCtrl.toggleCollapse(question) : trjctrCtrl.toggleCollapseSublevel(question)"
+      ng-click="trjctrCtrl.sublevel ? trjctrCtrl.toggleCollapseSublevel(question, trjctrCtrl.questions) : trjctrCtrl.toggleCollapse(question, trjctrCtrl.questions)"
       ng-if="( !trjctrCtrl.sublevel || question.Reponses) && !trjctrCtrl.readOnly">
-      <i class="fa" ng-class="((!trjctrCtrl.sublevel && trjctrCtrl.isCurrentQuestion(question)) || trjctrCtrl.sublevel && question.inProgress) ? 'fa-minus': 'fa-plus' "></i>
+      <i class="fa" ng-class="question.isOpen ? 'fa-minus': 'fa-plus' "></i>
     </button>
   </div>
 
   <trajectoire
-    ng-if="!trjctrCtrl.sublevel && trjctrCtrl.currentQuestionId === question.id || question.isSelected  || question.inProgress || trjctrCtrl.hasQuestionSelected(question)"
+    ng-if="!trjctrCtrl.sublevel && trjctrCtrl.currentQuestionId === question.id || question.isSelected  || question.isOpen || trjctrCtrl.hasQuestionSelected(question)"
     model="question.id"
     questions="question.Reponses"
     sublevel="true"

--- a/client/components/trajectoire/trajectoire.html
+++ b/client/components/trajectoire/trajectoire.html
@@ -1,31 +1,34 @@
 <div class="trajectoire-wrapper"
-  ng-class="{
-    'sub-level': trjctrCtrl.sublevel,
-    'main-level': !trjctrCtrl.sublevel}">
-  <div ng-repeat="question in trjctrCtrl.questions" ng-if="trjctrCtrl.filterQuestion(question)">
-    <div class="question" ng-class="{'question-active': question.isSelected}">
-      <button type="button" class="btn btn-link" ng-click="trjctrCtrl.toggleSelected(question)" ng-disabled="trjctrCtrl.readOnly">
-        <i class="fa" ng-class="question.isSelected ? 'fa-check-square-o' : 'fa-square-o'" aria-hidden="true" ng-if="trjctrCtrl.sublevel"></i>
-        {{question.Question ? (question.Question | capitalizeString) : (question.Libelle | capitalizeString)}}
-      </button>
-      <button type="button" class="btn btn-link showOnHover" ng-click="trjctrCtrl.newIssue(trjctrCtrl.root, question)">
-        Commenter
-      </button>
-      <button type="button" class="btn btn-link"
-        ng-click="trjctrCtrl.toggleCollapse(question)"
-        ng-if="!trjctrCtrl.sublevel && !trjctrCtrl.readOnly">
-        <i class="fa" ng-class="trjctrCtrl.isCurrentQuestion(question) ? 'fa-minus' : 'fa-plus'"></i>
-      </button>
-    </div>
-
-    <trajectoire
-      ng-if="trjctrCtrl.currentQuestionId === question.id || question.isSelected"
-      model="question.id"
-      questions="question.Reponses"
-      sublevel="true"
-      new-issue="trjctrCtrl.newIssue"
-      current-question-id="trjctrCtrl.currentQuestionId"
-      root="trjctrCtrl.getRootQuestion(question)"
-      read-only="trjctrCtrl.readOnly" />
+ng-class="{
+  'sub-level': trjctrCtrl.sublevel,
+  'main-level': !trjctrCtrl.sublevel}">
+<div ng-repeat="question in trjctrCtrl.questions" ng-if="trjctrCtrl.filterQuestion(question)">
+  <div class="question" ng-class="{'question-active': question.isSelected}">
+    <button type="button" class="btn btn-link" ng-click="trjctrCtrl.toggleSelected(question)" ng-disabled="trjctrCtrl.readOnly">
+      <i class="fa" ng-class="question.isSelected ? 'fa-check-square-o' : 'fa-square-o'" aria-hidden="true" ng-if="!question.Reponses && trjctrCtrl.sublevel"></i>
+      {{question.Question ? (question.Question | capitalizeString) : (question.Libelle | capitalizeString)}}
+    </button>
+    <button type="button" class="btn btn-link showOnHover" ng-click="trjctrCtrl.newIssue(trjctrCtrl.root, question)">
+      Commenter
+    </button>
+    <button type="button" class="btn btn-link"
+      ng-click="!trjctrCtrl.sublevel ? trjctrCtrl.toggleCollapse(question) : trjctrCtrl.toggleCollapseSublevel(question)"
+      ng-if="( !trjctrCtrl.sublevel || question.Reponses) && !trjctrCtrl.readOnly">
+      <i class="fa" ng-class="((!trjctrCtrl.sublevel && trjctrCtrl.isCurrentQuestion(question) )  || trjctrCtrl.sublevel && trjctrCtrl.isCurrentSubQuestion(question) ) ?  'fa-minus': 'fa-plus' "></i>
+    </button>
   </div>
+
+  <trajectoire
+    ng-if="((!trjctrCtrl.sublevel && trjctrCtrl.isCurrentQuestion(question) )  || trjctrCtrl.sublevel && trjctrCtrl.isCurrentSubQuestion(question) ) || question.isSelected "
+    model="question.id"
+    questions="question.Reponses"
+    sublevel="true"
+    new-issue="trjctrCtrl.newIssue"
+    current-question-id="trjctrCtrl.currentQuestionId"
+    current-sub-question-id="trjctrCtrl.currentSubQuestionId"
+    root="trjctrCtrl.getRootQuestion(question)"
+    read-only="trjctrCtrl.readOnly" />
+
+
+</div>
 </div>

--- a/client/components/trajectoire/trajectoire.html
+++ b/client/components/trajectoire/trajectoire.html
@@ -19,7 +19,7 @@ ng-class="{
   </div>
 
   <trajectoire
-    ng-if="((!trjctrCtrl.sublevel && trjctrCtrl.isCurrentQuestion(question) )  || trjctrCtrl.sublevel && trjctrCtrl.isCurrentSubQuestion(question) ) || question.isSelected "
+    ng-if="!trjctrCtrl.sublevel && trjctrCtrl.currentQuestionId === question.id || question.isSelected  || question.inProgress"
     model="question.id"
     questions="question.Reponses"
     sublevel="true"

--- a/client/components/trajectoire/trajectoire.html
+++ b/client/components/trajectoire/trajectoire.html
@@ -12,7 +12,7 @@ ng-class="{
       Commenter
     </button>
     <button type="button" class="btn btn-link"
-      ng-click="trjctrCtrl.sublevel ? trjctrCtrl.toggleCollapseSublevel(question, trjctrCtrl.questions) : trjctrCtrl.toggleCollapse(question, trjctrCtrl.questions)"
+      ng-click="trjctrCtrl.toggleCollapse(question, trjctrCtrl.questions)"
       ng-if="( !trjctrCtrl.sublevel || question.Reponses) && !trjctrCtrl.readOnly">
       <i class="fa" ng-class="question.isOpen ? 'fa-minus': 'fa-plus' "></i>
     </button>

--- a/client/components/trajectoire/trajectoire.html
+++ b/client/components/trajectoire/trajectoire.html
@@ -5,7 +5,7 @@ ng-class="{
 <div ng-repeat="question in trjctrCtrl.questions" ng-if="trjctrCtrl.filterQuestion(question)">
   <div class="question" ng-class="{'question-active': question.isSelected}">
     <button type="button" class="btn btn-link" ng-click="trjctrCtrl.toggleSelected(question)" ng-disabled="trjctrCtrl.readOnly">
-      <i class="fa" ng-class="question.isSelected ? 'fa-check-square-o' : 'fa-square-o'" aria-hidden="true" ng-if="!question.Reponses && trjctrCtrl.sublevel"></i>
+      <i class="fa" ng-class="question.isSelected ? 'fa-check-square-o' : 'fa-square-o'" aria-hidden="true" ng-if="trjctrCtrl.sublevel"></i>
       {{question.Question ? (question.Question | capitalizeString) : (question.Libelle | capitalizeString)}}
     </button>
     <button type="button" class="btn btn-link showOnHover" ng-click="trjctrCtrl.newIssue(trjctrCtrl.root, question)">
@@ -14,12 +14,12 @@ ng-class="{
     <button type="button" class="btn btn-link"
       ng-click="!trjctrCtrl.sublevel ? trjctrCtrl.toggleCollapse(question) : trjctrCtrl.toggleCollapseSublevel(question)"
       ng-if="( !trjctrCtrl.sublevel || question.Reponses) && !trjctrCtrl.readOnly">
-      <i class="fa" ng-class="((!trjctrCtrl.sublevel && trjctrCtrl.isCurrentQuestion(question) )  || trjctrCtrl.sublevel && question.inProgress) ?  'fa-minus': 'fa-plus' "></i>
+      <i class="fa" ng-class="((!trjctrCtrl.sublevel && trjctrCtrl.isCurrentQuestion(question)) || trjctrCtrl.sublevel && question.inProgress) ? 'fa-minus': 'fa-plus' "></i>
     </button>
   </div>
 
   <trajectoire
-    ng-if="!trjctrCtrl.sublevel && trjctrCtrl.currentQuestionId === question.id || question.isSelected  || question.inProgress"
+    ng-if="!trjctrCtrl.sublevel && trjctrCtrl.currentQuestionId === question.id || question.isSelected  || question.inProgress || trjctrCtrl.hasQuestionSelected(question)"
     model="question.id"
     questions="question.Reponses"
     sublevel="true"
@@ -28,7 +28,5 @@ ng-class="{
     current-sub-question-id="trjctrCtrl.currentSubQuestionId"
     root="trjctrCtrl.getRootQuestion(question)"
     read-only="trjctrCtrl.readOnly" />
-
-
 </div>
 </div>

--- a/client/components/trajectoire/trajectoire.html
+++ b/client/components/trajectoire/trajectoire.html
@@ -19,12 +19,11 @@ ng-class="{
   </div>
 
   <trajectoire
-    ng-if="!trjctrCtrl.sublevel && trjctrCtrl.currentQuestionId === question.id || question.isSelected  || question.isOpen || trjctrCtrl.hasQuestionSelected(question)"
+    ng-if="question.isOpen || question.isSelected || trjctrCtrl.hasQuestionSelected(question)"
     model="question.id"
     questions="question.Reponses"
     sublevel="true"
     new-issue="trjctrCtrl.newIssue"
-    current-question-id="trjctrCtrl.currentQuestionId"
     root="trjctrCtrl.getRootQuestion(question)"
     read-only="trjctrCtrl.readOnly" />
 </div>

--- a/client/components/trajectoire/trajectoire.html
+++ b/client/components/trajectoire/trajectoire.html
@@ -25,7 +25,6 @@ ng-class="{
     sublevel="true"
     new-issue="trjctrCtrl.newIssue"
     current-question-id="trjctrCtrl.currentQuestionId"
-    current-sub-question-id="trjctrCtrl.currentSubQuestionId"
     root="trjctrCtrl.getRootQuestion(question)"
     read-only="trjctrCtrl.readOnly" />
 </div>


### PR DESCRIPTION
Ajouter cette fonctionnalité sur tous les champs cochables qui disposent de champs d’un niveau inférieur. 
Cette fonctionnalité doit permettre de cocher un champ sans cocher les titres en amonts.